### PR TITLE
Fixed a escape error

### DIFF
--- a/ingress_export.js
+++ b/ingress_export.js
@@ -99,7 +99,7 @@ function wrapper() {
         var href = lat + "," + lng;
         var str= "";
         str = title;
-        str = str.replace(/\"/g, "\\\"");
+        str = str.replace(/\"/g, "\"\"");
         str = str.replace(";", "_");
         str = '"'+str+'"' + "," + href + "," + '"'+image+'"';
         if (window.plugin.keys && (typeof window.portals[portalGuid] !== "undefined")) {


### PR DESCRIPTION
'csv' lib of Python can't unescape '\\"' to '"', and we should use '""' (double quotes)