### PR TITLE
switch from .js to .user.js

### DIFF
--- a/ingress_export.user.js
+++ b/ingress_export.user.js
@@ -4,8 +4,8 @@
 // @category Information
 // @version 0.0.5
 // @namespace http://github.com/Zetaphor/IITC-Ingress-Portal-CSV-Export
-// @updateURL https://raw.githubusercontent.com/Zetaphor/IITC-Ingress-Portal-CSV-Export/master/ingress_export.js
-// @downloadURL https://raw.githubusercontent.com/Zetaphor/IITC-Ingress-Portal-CSV-Export/master/ingress_export.js
+// @updateURL https://raw.githubusercontent.com/Zetaphor/IITC-Ingress-Portal-CSV-Export/master/ingress_export.user.js
+// @downloadURL https://raw.githubusercontent.com/Zetaphor/IITC-Ingress-Portal-CSV-Export/master/ingress_export.user.js
 // @description Exports portals to a CSV list
 // @include https://*ingress.com/intel*
 // @include http://*ingress.com/intel*


### PR DESCRIPTION
This will allow one-click installation with most userscript extensions. Simple quality-of-life things.